### PR TITLE
CDH-74236: Fix HdfsLzoTextScanner::FillByteBuffer with null MemPool

### DIFF
--- a/hdfs-lzo-text-scanner.cc
+++ b/hdfs-lzo-text-scanner.cc
@@ -601,7 +601,11 @@ Status HdfsLzoTextScanner::ReadAndDecompressData(MemPool* pool) {
   // Attach any data that previously returned string slots may reference.
   bool has_string_slots = !scan_node_->tuple_desc()->string_slots().empty();
   if (has_string_slots) {
-    pool->AcquireData(block_buffer_pool_.get(), false);
+    if (pool != nullptr) {
+      pool->AcquireData(block_buffer_pool_.get(), false);
+    } else {
+      block_buffer_pool_->FreeAll();
+    }
     block_buffer_len_ = 0;
     block_buffer_ = block_buffer_ptr_ = nullptr;
   }

--- a/hdfs-lzo-text-scanner.h
+++ b/hdfs-lzo-text-scanner.h
@@ -149,6 +149,8 @@ class HdfsLzoTextScanner : public HdfsTextScanner {
   LzoFileHeader* header_;
 
   // Fills the byte buffer by reading and decompressing blocks.
+  // Attaches decompression buffers from previous calls that might still be referenced
+  // by returned batches to 'pool'. If 'pool' is nullptr the buffers are freed instead.
   virtual Status FillByteBuffer(MemPool* pool, bool* eosr, int num_bytes = 0);
 
   // Read header data and validate header.
@@ -173,12 +175,12 @@ class HdfsLzoTextScanner : public HdfsTextScanner {
   // Data will be in a mempool allocated buffer or in the disk I/O context memory
   // if the data was not compressed.
   // Attaches decompression buffers from previous calls that might still be referenced
-  // by returned batches to 'pool'.
+  // by returned batches to 'pool'. If 'pool' is nullptr the buffers are freed instead.
   Status ReadAndDecompressData(MemPool* pool);
 
   // Read compress data and recover from errosr.
   // Attaches decompression buffers from previous calls that might still be referenced
-  // by returned batches to 'pool'.
+  // by returned batches to 'pool'. If 'pool' is nullptr the buffers are freed instead.
   Status ReadData(MemPool* pool);
 
   // Callback for stream_ to determine how much to read past the scan range.


### PR DESCRIPTION
HdfsTextScanner::FillByteBuffer, which HdfsLzoTextScanner overrides,
takes a MemPool as a parameter. If a MemPool is provided,
FillByteBuffer should attach memory returned by previous calls to the
MemPool.

It is also valid to pass nullptr for the MemPool, in which case the
memory should just be freed. HdfsLzoTextScanner::FillByteBuffer did
not previously handle this case.

Testing:
- There is an existing test case that exercises this path in
  test_scan_ranges. It was previously not crashing due to bad luck.
  With a change that is about to go in to Impala (IMPALA-7272), it
  will start crashing without this fix.